### PR TITLE
Kallisto genomebam functionality

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,12 @@ resources:
   ontology:
     # gene ontology to download, used e.g. in goatools
     gene_ontology: "http://current.geneontology.org/ontology/go-basic.obo"
+    
+genomebam: 
+  # Produce .bam and .bam.bai files from the kallisto pseudoalignments
+  activate: true
+  # hg version for downloading chromosome size data. Should match the build specified above under ref:
+  hg_ver: hg38
 
 pca:
   labels:

--- a/workflow/envs/kallisto.yaml
+++ b/workflow/envs/kallisto.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - kallisto =0.46
+  - kallisto =0.46.1

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -292,7 +292,7 @@ def all_input(wildcards):
         # kallisto genomebam
         wanted_input.extend(
             expand(
-                "results/kallisto/{unit.sample}-{unit.unit}/pseudoalignment.bam",
+                "results/kallisto/{unit.sample}-{unit.unit}/pseudoalignments.bam",
                 unit=units[["sample","unit"]].itertuples(),
 
             )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -293,6 +293,7 @@ def all_input(wildcards):
         wanted_input.extend(
             expand(
                 "results/kallisto/{sample}-{unit}/pseudoalignment.bam",
+                unit=units[["sample","unit"]].itertuples(),
 
             )
         )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -292,7 +292,7 @@ def all_input(wildcards):
         # kallisto genomebam
         wanted_input.extend(
             expand(
-                "results/kallisto/{sample}-{unit}/pseudoalignment.bam",
+                "results/kallisto/{unit.sample}-{unit.unit}/pseudoalignment.bam",
                 unit=units[["sample","unit"]].itertuples(),
 
             )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -288,4 +288,13 @@ def all_input(wildcards):
             )
         )
 
+    if config["genomebam"]["activate"]:
+        # kallisto genomebam
+        wanted_input.extend(
+            expand(
+                "results/kallisto/{sample}-{unit}/pseudoalignment.bam",
+
+            )
+        )
+        
     return wanted_input

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -37,13 +37,15 @@ rule kallisto_genomebam:
         chrom="resources/chrom_edit.txt",
     output:
         dir=directory("results/kallisto/{sample}-{unit}"),
-        bam="results/kallisto/{sample}-{unit}/pseudoalignment.bam",
+        bam="results/kallisto/{sample}-{unit}/pseudoalignments.bam",
     log:
         "results/logs/kallisto/genomebam/{sample}-{unit}.log",
     params:
         extra=kallisto_params,
     conda:
         "../envs/kallisto.yaml"
+    resources:
+        tmpdir="./"
     shell:
         "kallisto quant -i {input.idx} -o {output.dir} "
         "{params.extra} --genomebam --gtf {input.gtf} --chromosomes {input.chrom} {input.fq} 2> {log}"

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,8 +1,8 @@
 def genomebam_inputs(wildcards):
     activated = config["genomebam"]["activate"]
-    if activated == "true":
+    if activated == True
         rule_input = "resources/chrom_edit.txt"
-    elif activated !="true":
+    elif activated == False:
         rule_input = "dummy.txt"
     return rule_input
         

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,6 +1,6 @@
 def genomebam_inputs(wildcards):
     activated = config["genomebam"]["activate"]
-    if activated == True
+    if activated == True:
         rule_input = "resources/chrom_edit.txt"
     elif activated == False:
         rule_input = "dummy.txt"

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -37,7 +37,7 @@ rule kallisto_genomebam:
         chrom="resources/chrom_edit.txt",
     output:
         directory("results/kallisto/{sample}-{unit}"),
-        directory("results/kallisto/{sample}-{unit}/pseudoalignment.bam"),
+        "results/kallisto/{sample}-{unit}/pseudoalignment.bam",
     log:
         "results/logs/kallisto/genomebam/{sample}-{unit}.log",
     params:

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -26,3 +26,22 @@ rule kallisto_quant:
     shell:
         "kallisto quant -i {input.idx} -o {output} "
         "{params.extra} {input.fq} 2> {log}"
+
+rule kallisto_genomebam:
+    input:
+        fq=get_trimmed,
+        idx="results/kallisto/transcripts.idx",
+        gtf="resources/transcripts.gtf.gz",
+        chrom="resources/chrom_edit.txt",
+    output:
+        directory("results/kallisto/{sample}-{unit}"),
+        directory("results/kallisto/{sample}-{unit}/pseudoalignment.bam"),
+    log:
+        "results/logs/kallisto/genomebam/{sample}-{unit}.log",
+    params:
+        extra=kallisto_params,
+    conda:
+        "../envs/kallisto.yaml"
+    shell:
+        "kallisto quant -i {input.idx} -o {output} "
+        "{params.extra} --genomebam --gtf {input.gtf} --chromosomes {input.chrom} {input.fq} 2> {log}"

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -31,7 +31,7 @@ rule kallisto_genomebam:
     input:
         fq=get_trimmed,
         idx="results/kallisto/transcripts.idx",
-        gtf="resources/transcripts.gtf.gz",
+        gtf="resources/genome.gtf",
         chrom="resources/chrom_edit.txt",
     output:
         directory("results/kallisto/{sample}-{unit}"),

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,4 +1,4 @@
-ruleorder: kallisto_genomebame > kallisto_quant
+ruleorder: kallisto_genomebam > kallisto_quant
 
 rule kallisto_index:
     input:

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -37,7 +37,7 @@ rule kallisto_genomebam:
         chrom="resources/chrom_edit.txt",
     output:
         dir=directory("results/kallisto/{sample}-{unit}"),
-        "results/kallisto/{sample}-{unit}/pseudoalignment.bam",
+        bam="results/kallisto/{sample}-{unit}/pseudoalignment.bam",
     log:
         "results/logs/kallisto/genomebam/{sample}-{unit}.log",
     params:

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,4 +1,4 @@
-def genomebam(wildcards):
+def genomebam_inputs(wildcards):
     activated = config["genomebam"]["activate"]
     if (activated == lower("true")):
         input = "resources/chrom_edit.txt"
@@ -42,7 +42,7 @@ rule kallisto_genomebam:
         fq=get_trimmed,
         idx="results/kallisto/transcripts.idx",
         gtf="resources/genome.gtf",
-        chrom=input,
+        chrom=genomebam_inputs,
     output:
         dir=directory("results/kallisto/{sample}-{unit}"),
         bam="results/kallisto/{sample}-{unit}/pseudoalignments.bam",

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,10 +1,10 @@
 def genomebam_inputs(wildcards):
     activated = config["genomebam"]["activate"]
-    if (activated == ("true","True","TRUE")):
-        input = "resources/chrom_edit.txt"
-    else:
-        input = "dummy.txt"
-    return input
+    if activated == "true":
+        rule_input = "resources/chrom_edit.txt"
+    elif activated !="true":
+        rule_input = "dummy.txt"
+    return rule_input
         
 ruleorder: kallisto_genomebam > kallisto_quant
 

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,3 +1,5 @@
+ruleorder: kallisto_genomebame > kallisto_quant
+
 rule kallisto_index:
     input:
         "resources/transcriptome.cdna.fasta",

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -36,7 +36,7 @@ rule kallisto_genomebam:
         gtf="resources/genome.gtf",
         chrom="resources/chrom_edit.txt",
     output:
-        directory("results/kallisto/{sample}-{unit}"),
+        dir=directory("results/kallisto/{sample}-{unit}"),
         "results/kallisto/{sample}-{unit}/pseudoalignment.bam",
     log:
         "results/logs/kallisto/genomebam/{sample}-{unit}.log",
@@ -45,5 +45,5 @@ rule kallisto_genomebam:
     conda:
         "../envs/kallisto.yaml"
     shell:
-        "kallisto quant -i {input.idx} -o {output} "
+        "kallisto quant -i {input.idx} -o {output.dir} "
         "{params.extra} --genomebam --gtf {input.gtf} --chromosomes {input.chrom} {input.fq} 2> {log}"

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,6 +1,6 @@
 def genomebam_inputs(wildcards):
     activated = config["genomebam"]["activate"]
-    if (activated == lower("true")):
+    if (activated == ("true","True","TRUE")):
         input = "resources/chrom_edit.txt"
     else:
         input = "dummy.txt"

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -1,3 +1,11 @@
+def genomebam(wildcards):
+    activated = config["genomebam"]["activate"]
+    if (activated == lower("true")):
+        input = "resources/chrom_edit.txt"
+    else:
+        input = "dummy.txt"
+    return input
+        
 ruleorder: kallisto_genomebam > kallisto_quant
 
 rule kallisto_index:
@@ -34,7 +42,7 @@ rule kallisto_genomebam:
         fq=get_trimmed,
         idx="results/kallisto/transcripts.idx",
         gtf="resources/genome.gtf",
-        chrom="resources/chrom_edit.txt",
+        chrom=input,
     output:
         dir=directory("results/kallisto/{sample}-{unit}"),
         bam="results/kallisto/{sample}-{unit}/pseudoalignments.bam",

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -124,3 +124,24 @@ rule get_spia_db:
     cache: True
     script:
         "../scripts/get-spia-db.R"
+
+rule get_chrom_size:
+    output:
+        "resources/chrom.txt",
+    params:
+        ver=config["genomebam"]["hg_ver"],
+    log:
+        "logs/chrom_size.log,
+    shell:
+        "curl -o chrom.txt https://hgdownload.cse.ucsc.edu/goldenPath/{params.ver}/bigZips/{params.ver}.chrom.sizes 2> {log}"
+
+rule chrom_edit:
+    input:
+        "resources/chrom.txt",
+    output:
+        "resources/chrom_edit.txt",
+    log:
+        "logs/chrom_edit.log",
+    shell:
+        "sed 's/chr//' {input} > chrom_edit.txt 2> {log}"
+

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -131,7 +131,7 @@ rule get_chrom_size:
     params:
         ver=config["genomebam"]["hg_ver"],
     log:
-        "logs/chrom_size.log,
+        "logs/chrom_size.log",
     shell:
         "curl -o chrom.txt https://hgdownload.cse.ucsc.edu/goldenPath/{params.ver}/bigZips/{params.ver}.chrom.sizes 2> {log}"
 

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -143,5 +143,5 @@ rule chrom_edit:
     log:
         "logs/chrom_edit.log",
     shell:
-        "sed 's/chr//' {input} > chrom_edit.txt 2> {log}"
+        "sed 's/chr//' {input} > resources/chrom_edit.txt 2> {log}"
 

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -133,7 +133,7 @@ rule get_chrom_size:
     log:
         "logs/chrom_size.log",
     shell:
-        "curl -o chrom.txt https://hgdownload.cse.ucsc.edu/goldenPath/{params.ver}/bigZips/{params.ver}.chrom.sizes 2> {log}"
+        "curl -o resources/chrom.txt https://hgdownload.cse.ucsc.edu/goldenPath/{params.ver}/bigZips/{params.ver}.chrom.sizes 2> {log}"
 
 rule chrom_edit:
     input:


### PR DESCRIPTION
Adds function to generate .bam and .bam.bai files from kallisto, which can be toggled on or off in the config file. When toggled on, the pipeline will:
-Download an additional .txt file containing chromosome size info from UCSC
-Edit this .txt file to be compatible with the Ensembl .gtf file (downloaded by an existing rule)
-Perform --genomebam in kallisto which will generate the additional .bam and .bam.bai files
