### PR TITLE
Kallisto star streamline

### DIFF
--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -61,7 +61,6 @@ rule kallisto_genomebam:
 rule star_align:
     input:
         unpack(get_trimmed_star),  
-        tmp="star_temp",
         index="resources/star_genome",
     output:
         aln="results/star/{sample}-{unit}/Aligned.sortedByCoord.out.bam",

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -58,13 +58,6 @@ rule kallisto_genomebam:
         "kallisto quant -i {input.idx} -o {output.dir} "
         "{params.extra} --genomebam --gtf {input.gtf} --chromosomes {input.chrom} {input.fq} 2> {log}"
         
-rule star_tempdir:
-    output: 
-        temp(directory("star_temp")),
-    shell:
-        "mkdir star_temp"
-        
-        
 rule star_align:
     input:
         unpack(get_trimmed_star),  
@@ -82,7 +75,7 @@ rule star_align:
         ),
     threads: 12
     resources: 
-        tmpdir="star_temp"
+        tmpdir="./"
     wrapper:
         "https://github.com/hehestevenhe/rna-seq-kallisto-sleuth/raw/kallisto_star_tmpdirs/workflow/wrapper"
         

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -72,11 +72,11 @@ rule star_align:
         extra="--outSAMtype BAM SortedByCoordinate --quantMode GeneCounts --sjdbGTFfile {} {}".format(
             "resources/genome.gtf", config["params"]["star"]
         ),
-    threads: 11
+    threads: 12
     resources: 
         tmpdir="./"
     wrapper:
-        "https://github.com/hehestevenhe/rna-seq-kallisto-sleuth/raw/kallisto_star_tmpdirs/workflow/wrapper"
+        "https://github.com/hehestevenhe/rna-seq-kallisto-sleuth/raw/kallisto_star_streamline/workflow/wrapper"
         
 rule star_bam_naming:
     input:

--- a/workflow/rules/quant.smk
+++ b/workflow/rules/quant.smk
@@ -72,7 +72,7 @@ rule star_align:
         extra="--outSAMtype BAM SortedByCoordinate --quantMode GeneCounts --sjdbGTFfile {} {}".format(
             "resources/genome.gtf", config["params"]["star"]
         ),
-    threads: 12
+    threads: 11
     resources: 
         tmpdir="./"
     wrapper:

--- a/workflow/wrapper/wrapper.py
+++ b/workflow/wrapper/wrapper.py
@@ -90,6 +90,7 @@ with tempfile.TemporaryDirectory() as star_tmp:
             )
             print("STAR alignment completed")
             q.put("stop")
+            time.sleep(10)
             break
    
     if snakemake.output.get("reads_per_gene"):

--- a/workflow/wrapper/wrapper.py
+++ b/workflow/wrapper/wrapper.py
@@ -57,7 +57,7 @@ elif "BAM Unsorted" in extra:
 else:
     stdout = "SAM"
     
-tmpdir=snakemake.resources.tmpdir
+#tmpdir=snakemake.resources.tmpdir
 
 with tempfile.TemporaryDirectory() as star_tmp:
 
@@ -65,7 +65,7 @@ with tempfile.TemporaryDirectory() as star_tmp:
     #Checks whether Queue is empty and runs
         while q.empty():
             time.sleep(10)
-            shell("sudo chmod -R 750 {tmpdir}/{star_tmp}")
+            shell("sudo chmod -R 750 {star_tmp}")
 
     if __name__ == "__main__":
     #Queue is a data structure used to communicate between process 
@@ -82,8 +82,8 @@ with tempfile.TemporaryDirectory() as star_tmp:
             " --readFilesIn {input_str}"
             " {readcmd}"
             " {extra}"
-            " --outTmpDir {tmpdir}/{star_tmp}/STARtmp"
-            " --outFileNamePrefix {tmpdir}/{star_tmp}/"
+            " --outTmpDir {star_tmp}/STARtmp"
+            " --outFileNamePrefix {star_tmp}/"
             " --outStd {stdout}"
             " > {snakemake.output.aln}"
             " {log}"
@@ -93,14 +93,14 @@ with tempfile.TemporaryDirectory() as star_tmp:
             break
    
     if snakemake.output.get("reads_per_gene"):
-        shell("cat {tmpdir}/{star_tmp}/ReadsPerGene.out.tab > {snakemake.output.reads_per_gene:q}")
+        shell("cat {star_tmp}/ReadsPerGene.out.tab > {snakemake.output.reads_per_gene:q}")
     if snakemake.output.get("chim_junc"):
-        shell("cat {tmpdir}/{star_tmp}/Chimeric.out.junction > {snakemake.output.chim_junc:q}")
+        shell("cat {star_tmp}/Chimeric.out.junction > {snakemake.output.chim_junc:q}")
     if snakemake.output.get("sj"):
-        shell("cat {tmpdir}/{star_tmp}/SJ.out.tab > {snakemake.output.sj:q}")
+        shell("cat {star_tmp}/SJ.out.tab > {snakemake.output.sj:q}")
     if snakemake.output.get("log"):
-        shell("cat {tmpdir}/{star_tmp}/Log.out > {snakemake.output.log:q}")
+        shell("cat {star_tmp}/Log.out > {snakemake.output.log:q}")
     if snakemake.output.get("log_progress"):
-        shell("cat {tmpdir}/{star_tmp}/Log.progress.out > {snakemake.output.log_progress:q}")
+        shell("cat {star_tmp}/Log.progress.out > {snakemake.output.log_progress:q}")
     if snakemake.output.get("log_final"):
-        shell("cat {tmpdir}/{star_tmp}/Log.final.out > {snakemake.output.log_final:q}")
+        shell("cat {star_tmp}/Log.final.out > {snakemake.output.log_final:q}")

--- a/workflow/wrapper/wrapper.py
+++ b/workflow/wrapper/wrapper.py
@@ -59,46 +59,48 @@ else:
     
 tmpdir=snakemake.resources.tmpdir
 
-def permissions():
-   #Checks whether Queue is empty and runs
-   while q.empty():
-      time.sleep(10)
-      shell("sudo chmod -R 755 {tmpdir}")
+with tempfile.TemporaryDirectory() as star_tmp:
 
-if __name__ == "__main__":
-   #Queue is a data structure used to communicate between process 
-   q = Queue()
-   #creating the process
-   p = Process(target=permissions)
-   #starting the process
-   p.start()
-   while True:
-    shell(
-    "STAR "
-    " --runThreadN {snakemake.threads}"
-    " --genomeDir {index}"
-    " --readFilesIn {input_str}"
-    " {readcmd}"
-    " {extra}"
-    " --outTmpDir {tmpdir}/STARtmp"
-    " --outFileNamePrefix {tmpdir}/"
-    " --outStd {stdout}"
-    " > {snakemake.output.aln}"
-    " {log}"
-    )
-    print("STAR alignment completed")
-    q.put("stop")
-    break
+    def permissions():
+    #Checks whether Queue is empty and runs
+        while q.empty():
+            time.sleep(10)
+            shell("sudo chmod -R 750 {tmpdir}/{star_tmp}")
+
+    if __name__ == "__main__":
+    #Queue is a data structure used to communicate between process 
+        q = Queue()
+        #creating the process
+        p = Process(target=permissions)
+        #starting the process
+        p.start()
+        while True:
+            shell(
+            "STAR "
+            " --runThreadN {snakemake.threads}"
+            " --genomeDir {index}"
+            " --readFilesIn {input_str}"
+            " {readcmd}"
+            " {extra}"
+            " --outTmpDir {tmpdir}/{star_tmp}/STARtmp"
+            " --outFileNamePrefix {tmpdir}/{star_tmp}/"
+            " --outStd {stdout}"
+            " > {snakemake.output.aln}"
+            " {log}"
+            )
+            print("STAR alignment completed")
+            q.put("stop")
+            break
    
-if snakemake.output.get("reads_per_gene"):
-    shell("cat {tmpdir}/ReadsPerGene.out.tab > {snakemake.output.reads_per_gene:q}")
-if snakemake.output.get("chim_junc"):
-    shell("cat {tmpdir}/Chimeric.out.junction > {snakemake.output.chim_junc:q}")
-if snakemake.output.get("sj"):
-    shell("cat {tmpdir}/SJ.out.tab > {snakemake.output.sj:q}")
-if snakemake.output.get("log"):
-    shell("cat {tmpdir}/Log.out > {snakemake.output.log:q}")
-if snakemake.output.get("log_progress"):
-    shell("cat {tmpdir}/Log.progress.out > {snakemake.output.log_progress:q}")
-if snakemake.output.get("log_final"):
-    shell("cat {tmpdir}/Log.final.out > {snakemake.output.log_final:q}")
+    if snakemake.output.get("reads_per_gene"):
+        shell("cat {tmpdir}/{star_tmp}/ReadsPerGene.out.tab > {snakemake.output.reads_per_gene:q}")
+    if snakemake.output.get("chim_junc"):
+        shell("cat {tmpdir}/{star_tmp}/Chimeric.out.junction > {snakemake.output.chim_junc:q}")
+    if snakemake.output.get("sj"):
+        shell("cat {tmpdir}/{star_tmp}/SJ.out.tab > {snakemake.output.sj:q}")
+    if snakemake.output.get("log"):
+        shell("cat {tmpdir}/{star_tmp}/Log.out > {snakemake.output.log:q}")
+    if snakemake.output.get("log_progress"):
+        shell("cat {tmpdir}/{star_tmp}/Log.progress.out > {snakemake.output.log_progress:q}")
+    if snakemake.output.get("log_final"):
+        shell("cat {tmpdir}/{star_tmp}/Log.final.out > {snakemake.output.log_final:q}")

--- a/workflow/wrapper/wrapper.py
+++ b/workflow/wrapper/wrapper.py
@@ -57,7 +57,7 @@ elif "BAM Unsorted" in extra:
 else:
     stdout = "SAM"
     
-#tmpdir=snakemake.resources.tmpdir
+tmpdir=snakemake.resources.tmpdir
 
 with tempfile.TemporaryDirectory() as star_tmp:
 
@@ -65,7 +65,7 @@ with tempfile.TemporaryDirectory() as star_tmp:
     #Checks whether Queue is empty and runs
         while q.empty():
             time.sleep(10)
-            shell("sudo chmod -R 750 {star_tmp}")
+            shell("sudo chmod -R 750 {tmpdir}/{star_tmp}")
 
     if __name__ == "__main__":
     #Queue is a data structure used to communicate between process 
@@ -82,8 +82,8 @@ with tempfile.TemporaryDirectory() as star_tmp:
             " --readFilesIn {input_str}"
             " {readcmd}"
             " {extra}"
-            " --outTmpDir {star_tmp}/STARtmp"
-            " --outFileNamePrefix {star_tmp}/"
+            " --outTmpDir {tmpdir}/{star_tmp}/STARtmp"
+            " --outFileNamePrefix {tmpdir}/{star_tmp}/"
             " --outStd {stdout}"
             " > {snakemake.output.aln}"
             " {log}"
@@ -93,14 +93,14 @@ with tempfile.TemporaryDirectory() as star_tmp:
             break
    
     if snakemake.output.get("reads_per_gene"):
-        shell("cat {star_tmp}/ReadsPerGene.out.tab > {snakemake.output.reads_per_gene:q}")
+        shell("cat {tmpdir}/{star_tmp}/ReadsPerGene.out.tab > {snakemake.output.reads_per_gene:q}")
     if snakemake.output.get("chim_junc"):
-        shell("cat {star_tmp}/Chimeric.out.junction > {snakemake.output.chim_junc:q}")
+        shell("cat {tmpdir}/{star_tmp}/Chimeric.out.junction > {snakemake.output.chim_junc:q}")
     if snakemake.output.get("sj"):
-        shell("cat {star_tmp}/SJ.out.tab > {snakemake.output.sj:q}")
+        shell("cat {tmpdir}/{star_tmp}/SJ.out.tab > {snakemake.output.sj:q}")
     if snakemake.output.get("log"):
-        shell("cat {star_tmp}/Log.out > {snakemake.output.log:q}")
+        shell("cat {tmpdir}/{star_tmp}/Log.out > {snakemake.output.log:q}")
     if snakemake.output.get("log_progress"):
-        shell("cat {star_tmp}/Log.progress.out > {snakemake.output.log_progress:q}")
+        shell("cat {tmpdir}/{star_tmp}/Log.progress.out > {snakemake.output.log_progress:q}")
     if snakemake.output.get("log_final"):
-        shell("cat {star_tmp}/Log.final.out > {snakemake.output.log_final:q}")
+        shell("cat {tmpdir}/{star_tmp}/Log.final.out > {snakemake.output.log_final:q}")


### PR DESCRIPTION
Removes the star_temp rule which creates a temporary directory for the star_align to work in. This streamlines the workflow as snakemake will no longer automatically re-generate all .bam.bai files as the star_temp is "updated" everytime, resulting in snakemake registering an updated input and re-running star_align on files with existing results. 
This pull also re-introduces the tempfile.TemporaryDirectory argument in the wrapper, such that all the tmp files created by star_align are cleaned up at the end. 
** There is a somewhat cosmetic issue introduced, whereas the outputs regarding the job scheduler from snakemake become improperly formatted, but the pipeline still functions correctly